### PR TITLE
Update lrInfiniteScroll.js

### DIFF
--- a/lrInfiniteScroll.js
+++ b/lrInfiniteScroll.js
@@ -8,16 +8,11 @@
                 var
                     lengthThreshold = attr.scrollThreshold || 50,
                     timeThreshold = attr.timeThreshold || 400,
-                    handler = scope.$eval(attr.lrInfiniteScroll),
                     promise = null,
                     lastRemaining = 9999;
 
                 lengthThreshold = parseInt(lengthThreshold, 10);
                 timeThreshold = parseInt(timeThreshold, 10);
-
-                if (!handler || !ng.isFunction(handler)) {
-                    handler = ng.noop;
-                }
 
                 element.bind('scroll', function () {
                     var
@@ -31,7 +26,7 @@
                             timeout.cancel(promise);
                         }
                         promise = timeout(function () {
-                            handler();
+                            scope.$apply(attr.lrInfiniteScroll);
                             promise = null;
                         }, timeThreshold);
                     }


### PR DESCRIPTION
In my tests handler always evaluated to noop, so the function never got called.
To get it working without an isolate scope, I used $apply() directly in the promise timeout function, which $eval()s its argument against the scope.
