### PR TITLE
Remove event handler when scope is destroyed

### DIFF
--- a/lrInfiniteScroll.js
+++ b/lrInfiniteScroll.js
@@ -37,6 +37,10 @@
                     }
                     lastRemaining = remaining;
                 });
+
+                scope.$on('$destroy', function () {
+                    element.unbind();
+                });
             }
 
         };


### PR DESCRIPTION
Make sure that the event handlers attached to this element are removed when the element is removed from the DOM